### PR TITLE
fix: don't start sound anew if already playing

### DIFF
--- a/apps/player/src/app/game/sound.ts
+++ b/apps/player/src/app/game/sound.ts
@@ -84,7 +84,7 @@ export class Sound {
   play(volume: number): void {
     this.howl.volume(normalizeVolume(volume));
     this.isScheduled = true;
-    if (this.howl.state() === 'loaded') {
+    if (this.howl.state() === 'loaded' && !this.isPlaying) {
       this.howl.play();
     }
   }


### PR DESCRIPTION
<!--
Thanks for spending the time to send this PR :D.

Please fill out the information below and make sure you're familiar
with the contributing guidelines (found in the CONTRIBUTING.md file).
-->

<!-- What changes are being made? (feature/bug) -->

### What

<!-- Why are these changes necessary? Link any related issues -->

### Why

<!-- If necessary add any additional notes on the implementation -->

### Notes
